### PR TITLE
Fix spelling mistake in Chapter 19

### DIFF
--- a/chapters/19.markdown
+++ b/chapters/19.markdown
@@ -56,7 +56,7 @@ This time Vim displays "1".  This is a very strong hint that Vim treats the
 integer "0" as "false" and the integer "1" as "true".  It's reasonable to assume
 that Vim treats *any* non-zero integer as "truthy", and this is indeed the case.
 
-We can also *set* options as variables.  Run the following commands:
+We can also *let* options as variables.  Run the following commands:
 
     :::vim
     :let &textwidth = 100


### PR DESCRIPTION
You have an example that uses 'let' to set an option, but the preceding text says 'we can use set'.
