### PR TITLE
Update 43.markdown

### DIFF
--- a/chapters/43.markdown
+++ b/chapters/43.markdown
@@ -92,7 +92,7 @@ Our plugin's repository will wind up looking like this:
     potion/
         README
         LICENSE
-        docs/
+        doc/
             potion.txt
         ftdetect/
             potion.vim


### PR DESCRIPTION
Very minor change, but something that threw me when I was adding a doc to a Vim plugin. Had to double check elsewhere that it was supposed to be "doc" instead of "docs".
