### PR TITLE
Chapter 3: Fix mapping of Ctrl to have an uppercase C.

### DIFF
--- a/chapters/03.markdown
+++ b/chapters/03.markdown
@@ -42,7 +42,7 @@ visually select the word.
 You can also map modifier keys like Ctrl and Alt.  Run this:
 
     :::vim
-    :map <c-d> dd
+    :map <C-d> dd
 
 Now pressing `Ctrl+d` on your keyboard will run `dd`.
 


### PR DESCRIPTION
```
:map <c-d> does not work
:map <C-d> does work
```
