### PR TITLE
minor change on the first chapter about :help messages

### DIFF
--- a/chapters/01.markdown
+++ b/chapters/01.markdown
@@ -60,7 +60,7 @@ Read `:help echo`.
 
 Read `:help echom`.
 
-Read `:help messages`.
+Read `:help :messages`.
 
 Add a line to your `~/.vimrc` file that displays a friendly ASCII-art cat
 (`>^.^<`) whenever you open Vim.

--- a/chapters/42.markdown
+++ b/chapters/42.markdown
@@ -21,7 +21,7 @@ Before we continue we need to talk about some vocabulary.
 
 I've been using the word "plugin" to mean "a big ol' hunk of Vimscript that does
 a bunch of related stuff".  Vim has a more specific meaning of "plugin", which
-is "a file in `~/.vim/plugins/`".
+is "a file in `~/.vim/plugin/`".
 
 Most of the time I'll be using the first definition.  I'll try to be clear when
 I mean the second.


### PR DESCRIPTION
:help messages gives the list of various vim messages as :help :messages
points to the correct documentation section.
