### PR TITLE
Fix sjl/learnvimscriptthehardway#63

### DIFF
--- a/chapters/53.markdown
+++ b/chapters/53.markdown
@@ -256,5 +256,5 @@ Experiment a bit and find out how autoloading variables behaves.
 
 Suppose you wanted to programatically force a reload of an autoload file Vim has
 already loaded, without bothering the user.  How might you do this?  You may
-want to read `:help silent!`.  Please don't ever do this in real life.
+want to read `:help :silent`.  Please don't ever do this in real life.
 


### PR DESCRIPTION
`:help silent!` throws an error `E149: Sorry, no help for silent!`, however, `:help :silent` opens up the expected help file.
