### PR TITLE
Ch20: make `:help internal-variables` a link

### DIFF
--- a/chapters/20.markdown
+++ b/chapters/20.markdown
@@ -31,7 +31,9 @@ that it's describing a scoped variable.
 Exercises
 ---------
 
-Skim over the list of scopes in `:help internal-variables`.  Don't worry if you
-don't know what some of them mean, just take a look and keep them in the back of
-your mind.
+Skim over the list of scopes in [`:help internal-variables`][internal-variables].
+Don't worry if you don't know what some of them mean, just take a look and keep
+them in the back of your mind.
+
+[internal-variables]: http://vimdoc.sourceforge.net/htmldoc/eval.html#internal-variables
 


### PR DESCRIPTION
Link to the official online Vim docs so that readers of the online version don’t have to open up Vim and type the command in.

Any `:help whatever` in the book could be replaced by a link to somewhere in the [online Vim documentation](http://vimdoc.sourceforge.net/htmldoc/), and changing all of them would be even better than changing just this one. But this link in particular is one I wish existed. Whenever I forget the types of scopes, I also forget the name of the Vim help topic about them. Instead, I have to search for [this page](http://learnvimscriptthehardway.stevelosh.com/chapters/20.html) on Google, then run the described command. It be easier if I could just click a link after finding this page. And I’m sure other readers would appreciate the convenience too.

I don’t know how you are publishing this book, but if this is the first link in the whole book, you may need to update your CSS styles or something so that “`:help internal-variables`” doesn’t look blue and underlined in the print version.
