### PR TITLE
get to the `messages` function help directly

### DIFF
--- a/chapters/01.markdown
+++ b/chapters/01.markdown
@@ -60,7 +60,7 @@ Read `:help echo`.
 
 Read `:help echom`.
 
-Read `:help messages`.
+Read `:help :messages`.
 
 Add a line to your `~/.vimrc` file that displays a friendly ASCII-art cat
 (`>^.^<`) whenever you open Vim.


### PR DESCRIPTION
In my Vim instance (7.4, included patches 1-52), if I type ':help messages',
i get line 756 of message.txt which is not the function documentation.

Typing ':help :messages' brings up line 16 of the same file, with the function documentation.

Feel free to discard if you think it is better for people to find out for themselves how to navigate to the right place.
