### PR TITLE
The Potion repo has changed ownership

### DIFF
--- a/chapters/41.markdown
+++ b/chapters/41.markdown
@@ -53,7 +53,7 @@ fairly simple.
 Make sure you can get the first couple examples in the pamphlet working in the
 Potion interpreter and by putting them in a `.pn` file.  If it seems like the
 interpreter isn't working check out [this
-issue](https://github.com/fogus/potion/issues/12) for a possible cause.
+issue](https://github.com/perl11/potion/issues/12) for a possible cause.
 
-[Potion]: http://fogus.github.com/potion/index.html
+[Potion]: http://perl11.github.com/potion/index.html
 [Io]: http://iolanguage.com/


### PR DESCRIPTION
I can't find any information about the change in ownership, but the github issue link now redirects to the perl11/potion repo. While the github issue link redirects properly, the github pages home page does not.

Thanks for the great book!