### PR TITLE
Consistency tweak in g:potion_command

### DIFF
--- a/chapters/53.markdown
+++ b/chapters/53.markdown
@@ -155,7 +155,7 @@ chapter:
 
     :::vim
     if !exists("g:potion_command")
-        let g:potion_command = "/Users/sjl/src/potion/potion"
+        let g:potion_command = "potion"
     endif
 
     function! PotionCompileAndRunFile()
@@ -221,7 +221,7 @@ directory and file name where they live.  Now change the
 
     :::vim
     if !exists("g:potion_command")
-        let g:potion_command = "/Users/sjl/src/potion/potion"
+        let g:potion_command = "potion"
     endif
 
     nnoremap <buffer> <localleader>r


### PR DESCRIPTION
In chapter 52 you describe how `g:potion_command` should default to the bare `potion` but that the variable

> will allow users to override it if `potion` isn't in their `$PATH` by
putting a line like `let g:potion_command = "/Users/sjl/src/potion/potion"` in
their `~/.vimrc` file.

For consistency's sake, it makes sense to also use `let g:potion_command = "potion"` in Chapter 53 rather than the (inlined) override.