### PR TITLE
Remove incorrectly reintroduced visual mode marker in namespacing example

### DIFF
--- a/chapters/34.markdown
+++ b/chapters/34.markdown
@@ -72,7 +72,7 @@ code.  Edit the file to look like this:
         if a:type ==# 'v'
             normal! `<v`>y
         elseif a:type ==# 'char'
-            normal! `[v`]y
+            normal! `[y`]
         else
             return
         endif


### PR DESCRIPTION
Related Issue: https://github.com/sjl/learnvimscriptthehardway/issues/106